### PR TITLE
spring-data-jpa를 포기하고 sort해보기 위해 메서드 이름 변경

### DIFF
--- a/src/main/java/com/tbl/faq/controllers/FaqController.java
+++ b/src/main/java/com/tbl/faq/controllers/FaqController.java
@@ -98,10 +98,10 @@ public class FaqController {
         List<Faq> faqList = null;
         switch (sortDateMethod) {
             case "ASC": // 이걸 구분하려면
-                faqList = faqService.findAllByOrderByDateAsc();
+                faqList = faqService.sortFaqAsc();
                 break;
             case "DESC":
-                faqList = faqService.findAllByOrderByDateDesc();
+                faqList = faqService.sortFaqDesc();
                 break;
         }
         return faqList;

--- a/src/main/java/com/tbl/faq/repository/FaqRepository.java
+++ b/src/main/java/com/tbl/faq/repository/FaqRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface FaqRepository extends JpaRepository<Faq, Integer> {
-    List<Faq> findAllByOrderByRegDateAsc();
-    List<Faq> findAllByOrderByRegDateDesc();
 }

--- a/src/main/java/com/tbl/faq/service/FaqService.java
+++ b/src/main/java/com/tbl/faq/service/FaqService.java
@@ -18,7 +18,7 @@ public interface FaqService {
     public void updateFaq(int id, Faq faq);
     public void deleteFaq(int id);
     public List<Faq> searchFaq(String keyword);
-    public List<Faq> findAllByOrderByDateAsc();
-    public List<Faq> findAllByOrderByDateDesc();
+    public List<Faq> sortFaqAsc();
+    public List<Faq> sortFaqDesc();
 //    public void close();
 }

--- a/src/main/java/com/tbl/faq/service/FaqServiceImpl.java
+++ b/src/main/java/com/tbl/faq/service/FaqServiceImpl.java
@@ -96,13 +96,13 @@ public class FaqServiceImpl implements FaqService {
     }
 
     @Override
-    public List<Faq> findAllByOrderByDateAsc() {
-        return faqRepository.findAllByOrderByRegDateAsc();
+    public List<Faq> sortFaqAsc() {
+        return null;
     }
 
     @Override
-    public List<Faq> findAllByOrderByDateDesc() {
-        return faqRepository.findAllByOrderByRegDateDesc();
+    public List<Faq> sortFaqDesc() {
+        return null;
     }
 
 //    @Override


### PR DESCRIPTION
sortFaqAsc, sortFaqDesc등으로 메서드 이름 변경함, 원본 원격저장소에서 바꾼 sortList등의 이름이 필요해서 pull request로 요청함